### PR TITLE
fix(SOUS-32): remove gin_help block

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -44,7 +44,6 @@ config:
       - gin.settings
       - block.block.gin_breadcrumbs
       - block.block.gin_content
-      - block.block.gin_help
       - block.block.gin_local_actions
       - block.block.gin_messages
       - block.block.gin_page_title


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/36718269/SOUS-32

**Functional Testing:**
1. Update your composer file for the sous project to use this branch to pull in sous-admin.
2. Go through the install steps for Sous.
3. When the log in url is provided, visit the site and verify you no longer see the missing block message for the gin_help block.