### PR TITLE
chore(SOUS-36): install config_log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/admin_toolbar": "*",
+        "drupal/config_log": "^4.0",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/field_group": "^3.4",
         "drupal/field_states_ui": "^3.0",

--- a/recipe.yml
+++ b/recipe.yml
@@ -12,6 +12,8 @@ install:
   - admin_toolbar
   - admin_toolbar_search
   - admin_toolbar_tools
+  # Install Config log.
+  - config_log
   # Install Gin theme and base modules that extend it.
   - gin
   - gin_toolbar


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/36718269/SOUS-36
d.o issue: https://www.drupal.org/project/sous/issues/3475880

**Functional Testing:**
1. Clone the sous drupal project
2. Update the composer.json to point fourkitchens/sous-admin to the SOUS-36 branch
3. complete the sous install.
4. Log in to the site and verify config_log is installed and enabled.